### PR TITLE
Add version number for i3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # Nodefetch
-Neofetch alternative written in Node.js by Rafal06 (github.com/rafal06/nodefetch).
+Neofetch alternative written in Node.js.  
+Why? Idk.
 
 ## Note
-Rafal06 tested it on Fedora Workstation, created support for showing versions of Gnome and KDE Plasma, and I added and tested support for showing versions of i3
+It's not complete and I tested it only on Fedora Workstation, although it should work with most distros with GNOME and KDE Plasma.
+
+Also, it's not affiliated with any already existing program with the same name.
 
 ## Screenshots
 ![fedora](https://cdn.discordapp.com/attachments/791628533339521031/947267078673547274/unknown.png)
-!![image](https://user-images.githubusercontent.com/83212176/156041566-0dc21239-bbd9-4c06-94f3-0e6d32ad58a7.png)
+![image](https://user-images.githubusercontent.com/83212176/156041566-0dc21239-bbd9-4c06-94f3-0e6d32ad58a7.png)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Nodefetch
-Neofetch alternative written in Node.js.  
-Why? Idk.
+Neofetch alternative written in Node.js by Rafal06 (github.com/rafal06/nodefetch).
 
 ## Note
-It's not complete and I tested it only on Fedora Workstation, although it should work with most distros with GNOME and KDE Plasma.
-
-Also, it's not affiliated with any already existing program with the same name.
+Rafal06 tested it on Fedora Workstation, created support for showing versions of Gnome and KDE Plasma, and I added and tested support for showing versions of i3
 
 ## Screenshots
 ![fedora](https://cdn.discordapp.com/attachments/791628533339521031/947267078673547274/unknown.png)
+!![image](https://user-images.githubusercontent.com/83212176/156041566-0dc21239-bbd9-4c06-94f3-0e6d32ad58a7.png)

--- a/index.js
+++ b/index.js
@@ -33,11 +33,14 @@ async function main() {
         case 'KDE':
             deVerCmd = 'plasmashell --version';
             break;
+        case 'i3':
+            deVerCmd = 'i3 --version';
+            break;
         default:
             deVerCmd = 'echo';
     }
     // Get DE version
-    const deVer = execSync(deVerCmd).toString().replace( /^\D+/g, '').replace(/[\n\r]/g, '');
+    const deVer = execSync(deVerCmd).toString().replace( /^\D+/g, '').replace(/[\n\r]/g, '').replace('3 ', '').replace(' © 2009 Michael Stapelberg and contributors', '');
 
     // Get the ascii logo
     // Look for the files in ascii dir


### PR DESCRIPTION
Added new case, witch gets i3's version, thru i3 --version command. Modified definition of deVer variable, to remove useless info, such as name of maintainer from output.